### PR TITLE
fix: typo in OpenGraph description

### DIFF
--- a/src/server/www/index.tmpl
+++ b/src/server/www/index.tmpl
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <title>RSS Parrot</title>
-  <meta name="description" content="Home of RSS Parrot, a fre Fediverse service that lets you turn Mastodon into an RSS or Atom feed reader." />
-  <meta name="og:description" content="Home of RSS Parrot, a fre Fediverse service that lets you turn Mastodon into an RSS or Atom feed reader." />
+  <meta name="description" content="Home of RSS Parrot, a free Fediverse service that lets you turn Mastodon into an RSS or Atom feed reader." />
+  <meta name="og:description" content="Home of RSS Parrot, a free Fediverse service that lets you turn Mastodon into an RSS or Atom feed reader." />
   <link rel="icon"
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦜</text></svg>">
   <link rel="stylesheet" href="/assets/style.css?ver={{ .Timestamp }}">


### PR DESCRIPTION
Hi!

I was sharing a link to RSS Parrot to some friends when I noticed a typo in the opengraph description for the website, so I figured I'd fix it.

P.S.: congrats on the service, I can already see myself using this a lot!

