### PR TITLE
Toot a limited number of old toots when first creating an account for a feed.

### DIFF
--- a/src/server/logic/feed_follower.go
+++ b/src/server/logic/feed_follower.go
@@ -314,7 +314,7 @@ func (ff *feedFollower) updateAccountPosts(
 
 	for _, k := range keepers {
 		fixPodcastLink(k.itm)
-		if err = ff.storePostIfNew(accountId, accountHandle, k.postTime, k.itm, true); err != nil {
+		if err = ff.storePostIfNew(accountId, accountHandle, k.postTime, k.itm); err != nil {
 			return
 		}
 	}
@@ -429,7 +429,6 @@ func (ff *feedFollower) storePostIfNew(
 	accountHandle string,
 	postTime time.Time,
 	itm *gofeed.Item,
-	tootNew bool,
 ) (err error) {
 	var isNew bool
 	plainTitle := stripHtml(itm.Title)
@@ -446,14 +445,14 @@ func (ff *feedFollower) storePostIfNew(
 	}
 	if isNew {
 		ff.metrics.NewPostSaved()
-		if err = ff.createToot(accountId, accountHandle, itm, tootNew); err != nil {
+		if err = ff.createToot(accountId, accountHandle, itm); err != nil {
 			return
 		}
 	}
 	return
 }
 
-func (ff *feedFollower) createToot(accountId int, accountHandle string, itm *gofeed.Item, sendToot bool) error {
+func (ff *feedFollower) createToot(accountId int, accountHandle string, itm *gofeed.Item) error {
 	prettyUrl := itm.Link
 	prettyUrl = strings.TrimPrefix(prettyUrl, "http://")
 	prettyUrl = strings.TrimPrefix(prettyUrl, "https://")
@@ -480,10 +479,8 @@ func (ff *feedFollower) createToot(accountId int, accountHandle string, itm *gof
 	if err != nil {
 		return err
 	}
-	if sendToot {
-		if err = ff.messenger.EnqueueBroadcast(accountHandle, statusId, tootedAt, content); err != nil {
-			return err
-		}
+	if err = ff.messenger.EnqueueBroadcast(accountHandle, statusId, tootedAt, content); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Instead of ignoring all existing feed items, toots a small number of feed items so that the activity stream does not start out completely empty.

* If I understand the code correctly, the last updated time will be the year 1900 for accounts that have just been created and before its feed is updated, so the old feed items will be included during `updateAccountPosts` on account creation.

* I am assuming that the reason old feed items were not tooted was to prevent something like a thousand toots from being sent at the same time for a large feed.  So if we are going to toot the most recent feed item, why not a bit more so it feels even less empty?  Let me know if my understanding is wrong so I can update the comments and restrict the number to one.

* A few parameters are now only ever true for some functions, so remove them to simplify things.

Resolves https://github.com/gugray/rss-parrot/issues/41.