### PR TITLE
Mark up the title more strongly.

### DIFF
--- a/src/server/texts/snippets/toot_new_post.html
+++ b/src/server/texts/snippets/toot_new_post.html
@@ -1,1 +1,1 @@
-<p>{{title}}</p><p><a href="{{url}}">{{prettyUrl}}</a></p><p>{{description}}</p>
+<p><strong>{{title}}</strong></p><p><a href="{{url}}">{{prettyUrl}}</a></p><p>{{description}}</p>


### PR DESCRIPTION
It would be nice if the title were to be formatted a little differently than the content to emphasize that it is the title.  This proposes that it be marked up with `<strong>`, which is the same thing that [Mastodon does for headers](https://docs.joinmastodon.org/spec/activitypub/#sanitization).