### PR TITLE
Keep format=rss query param for Squarespace RSS feeds

### DIFF
--- a/src/server/logic/feed_follower.go
+++ b/src/server/logic/feed_follower.go
@@ -154,6 +154,13 @@ func (ff *feedFollower) trimQueryParams(feedUrl *url.URL) {
 	if strings.Contains(feedUrl.Host, "archive.org") {
 		return
 	}
+
+	// Squarespace RSS feeds have `?format=rss` (https://support.squarespace.com/hc/en-us/articles/215761717-Using-RSS-feeds)
+	if strings.Contains(feedUrl.RawQuery, "format=rss") {
+		feedUrl.RawQuery = "format=rss"
+		return
+	}
+
 	// All otheres: remove query
 	feedUrl.RawQuery = ""
 }


### PR DESCRIPTION
Most (all?) squarespace RSS feeds use a `format=rss` query parameter, as documented [here](https://support.squarespace.com/hc/en-us/articles/215761717-Using-RSS-feeds):

> The RSS URL for any page is the full URL including the page slug, followed by ?format=rss.

This PR keeps only the `format=rss` query parameter, if it is present, removing any other ones.

This can be tested, for example, with <www.zerodayinitiative.com/blog/?format=rss>

This PR should close the main comment of #54 , but [`?feed=rss2`](https://github.com/gugray/rss-parrot/issues/54#issuecomment-2275703502) would stay broken.